### PR TITLE
Fix typo in pip install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 &nbsp;
 
 
-### Quickstart [![PyPI version](https://badge.fury.io/py/python-dotenvx.svg)](http://badge.fury.io/py/python-dotenvx) 
+### Quickstart [![PyPI version](https://badge.fury.io/py/python-dotenvx.svg)](http://badge.fury.io/py/python-dotenvx)
 
 Install and use it in code just like `python-dotenv`.
 
 ```sh
-pip install python-dotenv
+pip install python-dotenvx
 ```
 ```python
 # main.py


### PR DESCRIPTION
With the current instructions in the README, one would install the old `python-dotenv` instead of the new `python-dotenvx`.

I understand that `python-dotenvx` is still under construction, just wanted to point out the marked difference the missing letter `x` here would make.